### PR TITLE
Change incf to cl-incf and require cl-lib

### DIFF
--- a/cmake-format.el
+++ b/cmake-format.el
@@ -72,7 +72,7 @@ a `before-save-hook'."
                 (forward-line len)
                 (let ((text (buffer-substring start (point))))
                   (with-current-buffer target-buffer
-                    (decf line-offset len)
+                    (cl-decf line-offset len)
                     (goto-char (point-min))
                     (forward-line (- from len line-offset))
                     (insert text)))))

--- a/cmake-format.el
+++ b/cmake-format.el
@@ -18,7 +18,7 @@
 ;; This file is not part of GNU Emacs.
 
 ;;; Code:
-
+(require 'cl-lib)
 (defcustom cmake-format-command "cmake-format"
   "The 'cmake-format' command."
   :type 'string
@@ -79,7 +79,7 @@ a `before-save-hook'."
              ((equal action "d")
               (with-current-buffer target-buffer
                 (cmake-format--goto-line (- from line-offset))
-                (incf line-offset len)
+                (cl-incf line-offset len)
                 (cmake-format--delete-whole-line len)))
              (t
               (error "Invalid rcs patch or internal error in cmake-format--apply-rcs-patch")))))))


### PR DESCRIPTION
Fixes errors about `Symbol's function definiton is void: incf`.